### PR TITLE
Configurable version prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ jobs:
 
 The arguments required to run the task are outlined below.
 
-| Name           | Required | Description | Example | Default |
-| -------------- | -------- | ----------- | ------- | ------- |
-| `access-token` | Yes      | The token used to perform the commit actions such as commiting the version changes to the repository. | `ghp_123456789abcdefgfijklmnopqrstuvwxyz` | N/A |
-| `git-email`    | No       | The email address each commit will be associated with. | `my-git-bot@example.com` | `41898282+github-actions[bot]@users.noreply.github.com` |
-| `git-username` | No       | The GitHub username each commit will be associated with. | `my-git-bot` | `github-actions[bot]` |
-| `pom-path`     | No       | The path within your directory where the parent pom.xml you intend to change is located. | `./project` | `.` |
+| Name             | Required | Description                                                                                           | Example                                | Default                                                 |
+|------------------|----------|-------------------------------------------------------------------------------------------------------|----------------------------------------|---------------------------------------------------------|
+| `access-token`   | Yes      | The token used to perform the commit actions such as commiting the version changes to the repository. | `ghp_123456789abcdefgfijklmnopqrstuvwxyz` | N/A                                                     |
+| `git-email`      | No       | The email address each commit will be associated with.                                                | `my-git-bot@example.com`               | `41898282+github-actions[bot]@users.noreply.github.com` |
+| `git-username`   | No       | The GitHub username each commit will be associated with.                                              | `my-git-bot`                           | `github-actions[bot]`                                   |
+| `pom-path`       | No       | The path within your directory where the parent pom.xml you intend to change is located.              | `./project`                            | `.`                                                     |
+| `version-prefix` | No       | The prefix to include before the semantic version number.                                             | `ver`                                  | `v`                                                      |
 
 ### Running in a container
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
       The path within your directory where the parent pom.xml you intend to change is located.
     required: false
     default: .
+  version-prefix:
+    description: The prefix to include before the semantic version number.
+    required: false
+    default: v
 
 outputs:
   previous-version:
@@ -49,6 +53,7 @@ runs:
         GIT_EMAIL: ${{ inputs.git-email }}
         GIT_USERNAME: ${{ inputs.git-username }}
         POM_PATH: ${{ inputs.pom-path }}
+        VERSION_PREFIX: ${{ inputs.version-prefix }}
     - name: Print outputs
       run: echo "Updated version. $PREVIOUS_VERSION -> $NEW_VERSION"
       shell: bash

--- a/update_version.sh
+++ b/update_version.sh
@@ -29,6 +29,10 @@
 #     description: The path within your directory the pom.xml you intended to change is located.
 #     default: .
 #     example: ./project
+#  VERSION_PREFIX:
+#    description: The prefix to include before the semantic version number
+#    required: false
+#    default: v
 #   DEPLOY_ACTION
 #     required: false
 #     description: The action that will run upon the successful incrementation of the version. Note
@@ -156,7 +160,7 @@ make_version_changes()
   local repo="https://$GITHUB_ACTOR:$ACCESS_TOKEN@github.com/$GITHUB_REPOSITORY.git"
   git add ./\*pom.xml
   git -c "user.email=$GIT_EMAIL" -c "user.name=$GIT_USERNAME" commit -m "Increment version to $1 [skip ci]"
-  git tag "v$1"
+  git tag "$VERSION_PREFIX$1"
   git push "$repo" --follow-tags
   git push "$repo" --tags
 }
@@ -177,6 +181,10 @@ fi
 if [[ -z "$POM_PATH" ]]
 then
   POM_PATH="."
+fi
+if [[ -z "$VERSION_PREFIX" ]]
+then
+  VERSION_PREFIX="v"
 fi
 
 cd "$POM_PATH"

--- a/update_version.sh
+++ b/update_version.sh
@@ -182,7 +182,7 @@ if [[ -z "$POM_PATH" ]]
 then
   POM_PATH="."
 fi
-if [[ -z "$VERSION_PREFIX" ]]
+if [[ -z ${VERSION_PREFIX+x} ]]
 then
   VERSION_PREFIX="v"
 fi


### PR DESCRIPTION
- Adds a parameter named `version-prefix` that allows for the configuration of the prefix before the semantic version number. 
- Defaults to `v`, ensuring backward compatibility. 
- Accepts any string value or empty configuration like:
```
- uses: RichardInnocent/semantic-versioning-maven@0.0.35
  with:
    access-token: ${{ secrets.github_token }}
    version-prefix:
```

- includes readme doc changes.
- follows the naming/styling format of the original codebase. 
- if accepted, it's recommended to bump the tag version (currently 0.0.34) in the readme to (0.0.36)